### PR TITLE
implement frontmatter next-prev

### DIFF
--- a/django_spellbook/management/commands/processing/navigation.py
+++ b/django_spellbook/management/commands/processing/navigation.py
@@ -1,0 +1,254 @@
+# django_spellbook/management/commands/processing/navigation.py
+
+import logging
+from typing import List, Dict, Tuple
+from pathlib import Path
+from collections import defaultdict
+
+from django_spellbook.management.commands.processing.file_processor import ProcessedFile
+from django_spellbook.management.commands.processing.generator_utils import get_clean_url
+
+logger = logging.getLogger(__name__)
+
+
+class NavigationBuilder:
+    """
+    Builds prev/next navigation links for processed markdown files.
+
+    Navigation rules:
+    1. Files are grouped by content_app AND parent directory
+    2. Within each group, files are sorted alphabetically
+    3. index.md is treated as first file (sorted as '00-index.md')
+    4. Frontmatter overrides (prev/next in YAML) take precedence
+    5. Navigation respects app and directory boundaries
+    """
+
+    @staticmethod
+    def build_navigation(processed_files: List[ProcessedFile], content_app: str) -> None:
+        """
+        Build navigation links for all processed files.
+
+        Mutates ProcessedFile.context objects in-place to set prev_page and next_page.
+
+        Args:
+            processed_files: List of processed markdown files
+            content_app: Name of the content app (used for namespaced URLs)
+        """
+        if not processed_files:
+            logger.debug("No processed files to build navigation for")
+            return
+
+        # Group files by parent directory
+        groups = NavigationBuilder._group_files(processed_files)
+
+        # Build navigation for each group independently
+        for directory, files in groups.items():
+            logger.debug(f"Building navigation for {len(files)} files in {content_app}:{directory}")
+            NavigationBuilder._build_group_navigation(files, content_app, processed_files)
+
+    @staticmethod
+    def _group_files(processed_files: List[ProcessedFile]) -> Dict[str, List[ProcessedFile]]:
+        """
+        Group files by parent directory.
+
+        Args:
+            processed_files: List of processed markdown files
+
+        Returns:
+            Dictionary mapping directory to list of files
+        """
+        groups = defaultdict(list)
+
+        for pf in processed_files:
+            # Get parent directory from original path
+            parent_dir = Path(pf.original_path).parent
+
+            # Group by directory
+            groups[str(parent_dir)].append(pf)
+
+        return groups
+
+    @staticmethod
+    def _build_group_navigation(files: List[ProcessedFile], app: str, all_files: List[ProcessedFile]) -> None:
+        """
+        Build navigation for a group of files in the same app/directory.
+
+        Args:
+            files: List of files in the same app and directory
+            app: Content app name
+            all_files: All processed files (for path-based navigation lookup)
+        """
+        # Sort files alphabetically, with index.md treated as first
+        sorted_files = sorted(files, key=NavigationBuilder._get_sort_key)
+
+        # Build navigation chain
+        for i, current_file in enumerate(sorted_files):
+            # Check if frontmatter already specifies prev/next
+            fm_prev = NavigationBuilder._get_frontmatter_override(current_file, 'prev')
+            fm_next = NavigationBuilder._get_frontmatter_override(current_file, 'next')
+
+            # Set prev_page (use frontmatter override if available)
+            if fm_prev is not None:
+                # Normalize frontmatter value (supports both path and namespaced formats)
+                current_file.context.prev_page = NavigationBuilder._normalize_navigation_value(
+                    fm_prev, all_files, app
+                )
+                logger.debug(f"Using frontmatter prev for {current_file.relative_url}: {current_file.context.prev_page}")
+            elif i > 0:
+                prev_file = sorted_files[i - 1]
+                current_file.context.prev_page = NavigationBuilder._build_namespaced_url(prev_file, app)
+                logger.debug(f"Auto prev for {current_file.relative_url}: {current_file.context.prev_page}")
+            else:
+                # First file in group, no previous
+                current_file.context.prev_page = None
+
+            # Set next_page (use frontmatter override if available)
+            if fm_next is not None:
+                # Normalize frontmatter value (supports both path and namespaced formats)
+                current_file.context.next_page = NavigationBuilder._normalize_navigation_value(
+                    fm_next, all_files, app
+                )
+                logger.debug(f"Using frontmatter next for {current_file.relative_url}: {current_file.context.next_page}")
+            elif i < len(sorted_files) - 1:
+                next_file = sorted_files[i + 1]
+                current_file.context.next_page = NavigationBuilder._build_namespaced_url(next_file, app)
+                logger.debug(f"Auto next for {current_file.relative_url}: {current_file.context.next_page}")
+            else:
+                # Last file in group, no next
+                current_file.context.next_page = None
+
+    @staticmethod
+    def _get_sort_key(processed_file: ProcessedFile) -> str:
+        """
+        Generate sort key for a file, treating index.md as first.
+
+        Args:
+            processed_file: Processed markdown file
+
+        Returns:
+            String key for sorting (index.md becomes '000-index.md')
+        """
+        filename = Path(processed_file.original_path).name.lower()
+
+        # Treat index.md as '000-index.md' for sorting (sorts before any number)
+        if filename == 'index.md':
+            return '000-index.md'
+        else:
+            return filename
+
+    @staticmethod
+    def _get_frontmatter_override(processed_file: ProcessedFile, field: str) -> str:
+        """
+        Get frontmatter override for prev or next field.
+
+        Args:
+            processed_file: Processed markdown file
+            field: 'prev' or 'next'
+
+        Returns:
+            Frontmatter value if present, None otherwise
+        """
+        # The frontmatter parser should have already extracted prev/next
+        # and stored them in the context
+        return processed_file.context.get_safe_attr(field + '_page', None)
+
+    @staticmethod
+    def _is_namespaced_format(value: str) -> bool:
+        """
+        Check if value is in namespaced format (app:page) vs path format (path/to/page).
+
+        Namespaced format: "app_name:url_name"
+        - Has exactly one ':'
+        - Part before ':' contains no '/'
+        - Examples: "blog:page", "docs:---intro", "my_app:sub_page"
+
+        Path format: "path/to/page" or "page"
+        - No ':' OR ':' appears after '/'
+        - Examples: "intro", "guides/setup"
+
+        Args:
+            value: Navigation value from frontmatter
+
+        Returns:
+            True if namespaced format, False if path format
+        """
+        if ':' not in value:
+            return False  # No colon = path format
+
+        # Split on first colon
+        parts = value.split(':', 1)
+        if len(parts) != 2:
+            return False
+
+        app_part = parts[0]
+
+        # If app part contains '/', it's probably a path (invalid but treat as path)
+        if '/' in app_part:
+            return False
+
+        # If app part is empty, it's invalid (":something") - treat as path
+        if not app_part:
+            return False
+
+        # Looks like valid namespaced format: "app:page"
+        return True
+
+    @staticmethod
+    def _normalize_navigation_value(value: str, processed_files: List[ProcessedFile], app: str) -> str:
+        """
+        Convert frontmatter navigation value to namespaced URL format.
+
+        Supports two formats:
+        1. Namespaced: "blog:page-name" (use as-is)
+        2. Path-based: "path/to/page" or "page" (convert to namespaced)
+
+        Args:
+            value: Raw frontmatter value (prev or next)
+            processed_files: All processed files (for lookup)
+            app: Current content app
+
+        Returns:
+            Namespaced URL string
+        """
+        # Already in namespaced format - use as-is
+        if NavigationBuilder._is_namespaced_format(value):
+            logger.debug(f"Navigation value '{value}' is already namespaced")
+            return value
+
+        # Path-based - find matching file and convert
+        clean_path = get_clean_url(value)
+        logger.debug(f"Converting path-based navigation '{value}' (clean: '{clean_path}')")
+
+        # Search for matching file by relative_url
+        for pf in processed_files:
+            pf_clean_url = get_clean_url(pf.relative_url)
+            if pf_clean_url == clean_path:
+                namespaced = NavigationBuilder._build_namespaced_url(pf, app)
+                logger.debug(f"Found matching file: '{pf.relative_url}' -> '{namespaced}'")
+                return namespaced
+
+        # Fallback: construct namespaced URL from path
+        # (in case file isn't in current batch or will be added later)
+        url_name = clean_path.replace('/', '_')
+        fallback = f"{app}:{url_name}"
+        logger.debug(f"No matching file found, using fallback: '{fallback}'")
+        return fallback
+
+    @staticmethod
+    def _build_namespaced_url(processed_file: ProcessedFile, app: str) -> str:
+        """
+        Generate namespaced URL for a processed file.
+
+        Format: app_name:url_name (e.g., 'blog:01_intro', 'docs:setup')
+
+        Args:
+            processed_file: Processed markdown file
+            app: Content app name
+
+        Returns:
+            Namespaced URL string
+        """
+        clean_url = get_clean_url(processed_file.relative_url)
+        url_name = clean_url.replace('/', '_')
+
+        return f"{app}:{url_name}"

--- a/django_spellbook/management/commands/processing/url_view_generator.py
+++ b/django_spellbook/management/commands/processing/url_view_generator.py
@@ -9,6 +9,7 @@ from django_spellbook.management.commands.processing.file_processor import Proce
 from django_spellbook.management.commands.processing.url_generator import URLGenerator
 from django_spellbook.management.commands.processing.view_generator import ViewGenerator
 from django_spellbook.management.commands.processing.file_writer import FileWriter
+from django_spellbook.management.commands.processing.navigation import NavigationBuilder
 
 logger = logging.getLogger(__name__)
 
@@ -57,12 +58,17 @@ class URLViewGenerator:
             toc: Table of contents dictionary
         """
         try:
+            # Build navigation links BEFORE generating views
+            # This mutates the ProcessedFile.context objects to add prev_page and next_page
+            logger.info(f"Building navigation for {len(processed_files)} files")
+            NavigationBuilder.build_navigation(processed_files, self.content_app)
+
             # Generate URL patterns
             url_patterns = self.url_generator.generate_url_patterns(processed_files)
-            
+
             # Generate view functions
             view_functions = self.view_generator.generate_view_functions(processed_files)
-            
+
             # Write to files
             self.file_writer.write_urls_file(url_patterns)
             self.file_writer.write_views_file(view_functions, toc)

--- a/django_spellbook/markdown/context.py
+++ b/django_spellbook/markdown/context.py
@@ -81,7 +81,9 @@ class SpellbookContext:
             'url_name': url_name,
             'namespaced_url': f"{content_app}:{url_name}",
             'word_count': self.word_count,
-            'reading_time_minutes': self.reading_time_minutes
+            'reading_time_minutes': self.reading_time_minutes,
+            'prev_page': self.get_safe_attr('prev_page', None),
+            'next_page': self.get_safe_attr('next_page', None)
         }
         
         return metadata

--- a/django_spellbook/markdown/frontmatter.py
+++ b/django_spellbook/markdown/frontmatter.py
@@ -14,7 +14,7 @@ MODIFIED_KEYS = ['modified', 'modified_at', 'updated', 'updated_at']
 
 # --- Keys to exclude from custom_meta ---
 # Includes standard keys and the date aliases we might consume
-RESERVED_META_KEYS = ['title', 'is_public', 'tags', 'author'] + PUBLISHED_KEYS + MODIFIED_KEYS
+RESERVED_META_KEYS = ['title', 'is_public', 'tags', 'author', 'prev', 'next'] + PUBLISHED_KEYS + MODIFIED_KEYS
 # Make the check case-insensitive later for robustness
 LOWERCASE_RESERVED_META_KEYS = [k.lower() for k in RESERVED_META_KEYS]
 
@@ -102,6 +102,10 @@ class FrontMatterParser:
             if k.lower() not in LOWERCASE_RESERVED_META_KEYS
         }
 
+        # --- Extract prev/next from frontmatter (optional overrides) ---
+        prev_page = self.metadata.get('prev')  # Can be None or namespaced URL like 'blog:intro'
+        next_page = self.metadata.get('next')  # Can be None or namespaced URL like 'docs:setup'
+
         # --- Create context ---
         return SpellbookContext(
             title=titlefy(remove_leading_dash(
@@ -120,8 +124,8 @@ class FrontMatterParser:
             author=self.metadata.get('author'),
             custom_meta=custom_meta_data,
             toc={},  # This will be filled by the command later
-            next_page=None, # Filled later
-            prev_page=None  # Filled later
+            next_page=next_page,  # From frontmatter or None (will be auto-filled by NavigationBuilder)
+            prev_page=prev_page   # From frontmatter or None (will be auto-filled by NavigationBuilder)
         )
 
 def multi_bool(value):

--- a/django_spellbook/templates/django_spellbook/metadata/for_dev.html
+++ b/django_spellbook/templates/django_spellbook/metadata/for_dev.html
@@ -1,15 +1,14 @@
-<div class="sb-metadata sb-metadata-dev sb-rounded sb-border sb-border-info-25 sb-p-3 sb-my-4 sb-bg-info-25 sb-w-full">
-  <h3 class="sb-metadata-title sb-text-lg sb-mb-2 sb-font-bold sb-info">Developer Metadata</h3>
-  {% if metadata.author %}<p class="sb-metadata-author sb-text-sm sb-mb-3 sb-text-secondary">by {{ metadata.author }}</p>{% endif %}
+<div class="sb-metadata sb-metadata-dev sb-rounded sb-border sb-p-3 sb-my-4 sb-bg-secondary-25 sb-w-full">
+  <h3 class="sb-metadata-title sb-text-lg sb-mb-2 sb-font-bold sb-primary">Developer Metadata</h3>
+  {% if metadata.author %}<p class="sb-metadata-author sb-text-sm sb-mb-3 sb-opacity-50">by {{ metadata.author }}</p>{% endif %}
 
   <div class="sb-metadata-grid sb-grid sb-grid-cols-1 sb-md:grid-cols-2 sb-gap-2">
-
 
     {% comment %} URL Path (Grid Item 1 on md+) {% endcomment %}
     {% if metadata.url_path %}
     <div class="sb-metadata-item sb-flex sb-items-center sb-gap-1">
       <span class="sb-metadata-label sb-text-sm sb-font-bold sb-secondary">URL Path:</span>
-      <code class="sb-metadata-code sb-text-sm sb-bg-black-25 sb-px-1 sb-py-0.5 sb-rounded sb-font-mono">{{ metadata.url_path }}</code>
+      <code class="sb-metadata-code sb-text-sm sb-bg-secondary-10 sb-px-1 sb-py-0.5 sb-rounded sb-font-mono sb-primary">{{ metadata.url_path }}</code>
     </div>
     {% endif %}
 
@@ -17,7 +16,7 @@
     {% if metadata.namespace %}
     <div class="sb-metadata-item sb-flex sb-items-center sb-gap-1">
       <span class="sb-metadata-label sb-text-sm sb-font-bold sb-secondary">App Name:</span>
-      <code class="sb-metadata-code sb-text-sm sb-bg-black-25 sb-px-1 sb-py-0.5 sb-rounded sb-font-mono">{{ metadata.namespace }}</code>
+      <code class="sb-metadata-code sb-text-sm sb-bg-secondary-10 sb-px-1 sb-py-0.5 sb-rounded sb-font-mono sb-primary">{{ metadata.namespace }}</code>
     </div>
     {% endif %}
 
@@ -25,7 +24,7 @@
     {% if metadata.namespaced_url %}
     <div class="sb-metadata-item sb-flex sb-items-center sb-gap-1">
       <span class="sb-metadata-label sb-text-sm sb-font-bold sb-secondary">URL Name:</span>
-      <code class="sb-metadata-code sb-text-sm sb-bg-black-25 sb-px-1 sb-py-0.5 sb-rounded sb-font-mono">{{ metadata.namespaced_url }}</code>
+      <code class="sb-metadata-code sb-text-sm sb-bg-secondary-10 sb-px-1 sb-py-0.5 sb-rounded sb-font-mono sb-primary">{{ metadata.namespaced_url }}</code>
     </div>
     {% endif %}
   </div> {# End of sb-metadata-grid #}

--- a/django_spellbook/templates/django_spellbook/metadata/for_user.html
+++ b/django_spellbook/templates/django_spellbook/metadata/for_user.html
@@ -1,3 +1,4 @@
+{% load spellbook_tags %}
 <div class="sb-metadata sb-metadata-user sb-rounded sb-border sb-p-3 sb-my-4 sb-bg-secondary-25 sb-w-full">
   {% if metadata.title %}<h3 class="sb-metadata-title sb-text-lg sb-mb-2 sb-font-bold sb-primary">{{ metadata.title }}</h3>{% endif %}
   {% if metadata.author %}<p class="sb-metadata-author sb-text-sm sb-mb-1 sb-opacity-50 sb-mt-n2">by {{ metadata.author }}</p>{% endif %}
@@ -55,7 +56,7 @@
     <div class="sb-flex sb-items-center sb-gap-1 sb-flex-wrap">
       <span class="sb-metadata-label sb-text-sm sb-font-bold sb-secondary">Tags:</span>
       {% for tag in metadata.tags %}
-        <span class="sb-tag sb-bg-primary-25 sb-text-primary sb-text-xs sb-px-2 sb-py-1 sb-rounded-full">{{ tag }}</span>
+        <span class="sb-tag sb-bg-secondary-10 sb-primary sb-text-xs sb-px-2 sb-py-1 sb-rounded-full">{{ tag }}</span>
       {% endfor %}
     </div>
   </div>
@@ -63,18 +64,20 @@
 
   {% comment %} Navigation Links {% endcomment %}
   {% if metadata.prev_page or metadata.next_page %}
-  <div class="sb-metadata-navigation sb-flex sb-justify-between sb-mt-3 sb-pt-2 sb-border-t sb-border-secondary-25">
+  <div class="sb-metadata-navigation sb-flex sb-justify-between sb-gap-2 sb-mt-3 sb-pt-2 sb-border-secondary-25">
     {% if metadata.prev_page %}
-    <a href="{{ metadata.prev_page }}" class="sb-metadata-nav-link sb-text-sm sb-flex sb-items-center sb-gap-1 sb-primary sb-hover:primary-75">
-      <span>←</span> Previous
+    <a href="{% spellbook_url metadata.prev_page %}" class="sb-metadata-nav-link sb-flex sb-items-center sb-gap-1 sb-px-3 sb-py-2 sb-rounded sb-bg-secondary-10 sb-primary sb-no-underline sb-transition sb-hover:bg-secondary-25 sb-hover:primary-75">
+      <span>←</span>
+      <span class="sb-text-sm">Previous</span>
     </a>
     {% else %}
     <span></span> {# Placeholder for alignment #}
     {% endif %}
 
     {% if metadata.next_page %}
-    <a href="{{ metadata.next_page }}" class="sb-metadata-nav-link sb-text-sm sb-flex sb-items-center sb-gap-1 sb-primary sb-hover:primary-75">
-      Next <span>→</span>
+    <a href="{% spellbook_url metadata.next_page %}" class="sb-metadata-nav-link sb-flex sb-items-center sb-gap-1 sb-px-3 sb-py-2 sb-rounded sb-bg-secondary-10 sb-primary sb-no-underline sb-transition sb-hover:bg-secondary-25 sb-hover:primary-75">
+      <span class="sb-text-sm">Next</span>
+      <span>→</span>
     </a>
     {% endif %}
   </div>

--- a/django_spellbook/views_blog.py
+++ b/django_spellbook/views_blog.py
@@ -24,5 +24,7 @@ def view_first_post(request):
         'namespaced_url': 'blog:first-post',
         'word_count': 8,
         'reading_time_minutes': 1,
+        'prev_page': None,
+        'next_page': None,
     }
     return render(request, 'blog/spellbook_md/first-post.html', context)

--- a/django_spellbook/views_docs.py
+++ b/django_spellbook/views_docs.py
@@ -24,5 +24,7 @@ def view_intro(request):
         'namespaced_url': 'docs:intro',
         'word_count': 6,
         'reading_time_minutes': 1,
+        'prev_page': None,
+        'next_page': None,
     }
     return render(request, 'docs/spellbook_md/intro.html', context)

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_namespace_packages
 
 setup(
     name='django-spellbook',
-    version='0.1.18b6',  # Increment version
+    version='0.1.18b11',  # Increment version
     author='Mathew Storm',
     author_email='mathewstormdev@gmail.com',
     description='A Django library for creating and managing content blocks in markdown for developers and bloggers',

--- a/tests/test_navigation.py
+++ b/tests/test_navigation.py
@@ -1,0 +1,406 @@
+# tests/test_navigation.py
+
+import unittest
+from unittest.mock import Mock
+from pathlib import Path
+from django.test import TestCase
+
+from django_spellbook.management.commands.processing.navigation import NavigationBuilder
+from django_spellbook.management.commands.processing.file_processor import ProcessedFile
+from django_spellbook.markdown.context import SpellbookContext
+
+
+class TestNavigationBuilder(TestCase):
+    """Tests for the NavigationBuilder class."""
+
+    def setUp(self):
+        """Set up test fixtures."""
+        self.test_dir = Path("/test/docs")
+
+    def _create_processed_file(self, filename: str, app: str = "blog", directory: Path = None, prev=None, next=None):
+        """Helper to create a ProcessedFile with SpellbookContext."""
+        if directory is None:
+            directory = self.test_dir
+
+        # relative_url should match what get_clean_url produces (removes leading dashes, keeps internal dashes)
+        relative_url = filename.replace('.md', '')
+
+        # Create a SpellbookContext with required fields
+        context = SpellbookContext(
+            title=filename.replace('.md', '').replace('-', ' ').title(),
+            url_path=f"test/{relative_url}",
+            raw_content=f"# {filename}\n\nTest content",
+            prev_page=prev,
+            next_page=next
+        )
+
+        # Add namespace for navigation grouping
+        context.namespace = app
+
+        return ProcessedFile(
+            original_path=directory / filename,
+            html_content=f"<h1>{filename}</h1>",
+            template_path=Path(f"/templates/{filename}.html"),
+            relative_url=relative_url,  # This is what gets passed to get_clean_url
+            context=context
+        )
+
+    def test_empty_file_list(self):
+        """Test that empty file list doesn't raise errors."""
+        NavigationBuilder.build_navigation([], "blog")
+        # Should complete without error
+
+    def test_single_file_no_navigation(self):
+        """Test that a single file has no prev/next links."""
+        file = self._create_processed_file("intro.md")
+
+        NavigationBuilder.build_navigation([file], "blog")
+
+        self.assertIsNone(file.context.prev_page)
+        self.assertIsNone(file.context.next_page)
+
+    def test_two_files_alphabetical_navigation(self):
+        """Test navigation between two files sorted alphabetically."""
+        file1 = self._create_processed_file("01-intro.md")
+        file2 = self._create_processed_file("02-setup.md")
+
+        NavigationBuilder.build_navigation([file2, file1], "blog")  # Unsorted order
+
+        # file1 should have next to file2
+        self.assertIsNone(file1.context.prev_page)
+        self.assertEqual(file1.context.next_page, "blog:02-setup")  # Dashes preserved in URL
+
+        # file2 should have prev to file1
+        self.assertEqual(file2.context.prev_page, "blog:01-intro")  # Dashes preserved in URL
+        self.assertIsNone(file2.context.next_page)
+
+    def test_three_files_complete_chain(self):
+        """Test navigation chain with three files."""
+        file1 = self._create_processed_file("01-intro.md")
+        file2 = self._create_processed_file("02-setup.md")
+        file3 = self._create_processed_file("03-usage.md")
+
+        NavigationBuilder.build_navigation([file3, file1, file2], "blog")
+
+        # file1: no prev, next to file2
+        self.assertIsNone(file1.context.prev_page)
+        self.assertEqual(file1.context.next_page, "blog:02-setup")
+
+        # file2: prev to file1, next to file3
+        self.assertEqual(file2.context.prev_page, "blog:01-intro")
+        self.assertEqual(file2.context.next_page, "blog:03-usage")
+
+        # file3: prev to file2, no next
+        self.assertEqual(file3.context.prev_page, "blog:02-setup")
+        self.assertIsNone(file3.context.next_page)
+
+    def test_index_md_sorted_first(self):
+        """Test that index.md is treated as first file in navigation."""
+        file_index = self._create_processed_file("index.md")
+        file1 = self._create_processed_file("01-intro.md")
+        file2 = self._create_processed_file("02-setup.md")
+
+        NavigationBuilder.build_navigation([file1, file2, file_index], "blog")
+
+        # index should be first
+        self.assertIsNone(file_index.context.prev_page)
+        self.assertEqual(file_index.context.next_page, "blog:01-intro")
+
+        # 01-intro should have prev to index
+        self.assertEqual(file1.context.prev_page, "blog:index")
+        self.assertEqual(file1.context.next_page, "blog:02-setup")
+
+    def test_directory_boundaries_respected(self):
+        """Test that files in different directories don't link to each other."""
+        # Files in root directory
+        file1 = self._create_processed_file("intro.md", directory=self.test_dir)
+
+        # Files in subdirectory
+        subdir = self.test_dir / "advanced"
+        file2 = self._create_processed_file("performance.md", directory=subdir)
+
+        NavigationBuilder.build_navigation([file1, file2], "blog")
+
+        # Both files should have no navigation (different directories)
+        self.assertIsNone(file1.context.prev_page)
+        self.assertIsNone(file1.context.next_page)
+        self.assertIsNone(file2.context.prev_page)
+        self.assertIsNone(file2.context.next_page)
+
+    def test_app_namespace_used_in_urls(self):
+        """Test that the provided app parameter is used in generated URLs."""
+        file1 = self._create_processed_file("aaa.md")  # First alphabetically
+        file2 = self._create_processed_file("zzz.md")  # Last alphabetically
+
+        # Pass "myapp" as the content_app
+        NavigationBuilder.build_navigation([file1, file2], "myapp")
+
+        # Both files should use "myapp:" namespace
+        self.assertEqual(file1.context.next_page, "myapp:zzz")
+        self.assertEqual(file2.context.prev_page, "myapp:aaa")
+
+    def test_frontmatter_override_prev(self):
+        """Test that frontmatter prev override is respected."""
+        file1 = self._create_processed_file("01-intro.md")
+        file2 = self._create_processed_file("02-setup.md", prev="blog:custom_prev")
+        file3 = self._create_processed_file("03-usage.md")
+
+        NavigationBuilder.build_navigation([file1, file2, file3], "blog")
+
+        # file2 should use frontmatter override for prev
+        self.assertEqual(file2.context.prev_page, "blog:custom_prev")
+        # But next should still be auto-calculated
+        self.assertEqual(file2.context.next_page, "blog:03-usage")
+
+    def test_frontmatter_override_next(self):
+        """Test that frontmatter next override is respected."""
+        file1 = self._create_processed_file("01-intro.md")
+        file2 = self._create_processed_file("02-setup.md", next="blog:custom_next")
+        file3 = self._create_processed_file("03-usage.md")
+
+        NavigationBuilder.build_navigation([file1, file2, file3], "blog")
+
+        # file2 should use frontmatter override for next
+        self.assertEqual(file2.context.next_page, "blog:custom_next")
+        # But prev should still be auto-calculated
+        self.assertEqual(file2.context.prev_page, "blog:01-intro")
+
+    def test_frontmatter_override_both(self):
+        """Test that both prev and next frontmatter overrides work together."""
+        file1 = self._create_processed_file("01-intro.md")
+        file2 = self._create_processed_file("02-setup.md", prev="blog:custom_prev", next="blog:custom_next")
+        file3 = self._create_processed_file("03-usage.md")
+
+        NavigationBuilder.build_navigation([file1, file2, file3], "blog")
+
+        # file2 should use both frontmatter overrides
+        self.assertEqual(file2.context.prev_page, "blog:custom_prev")
+        self.assertEqual(file2.context.next_page, "blog:custom_next")
+
+    def test_namespaced_url_generation(self):
+        """Test that namespaced URLs are generated correctly."""
+        file1 = self._create_processed_file("intro.md")
+        file2 = self._create_processed_file("setup.md")
+
+        NavigationBuilder.build_navigation([file1, file2], "blog")
+
+        # Check URL format: app:url_name
+        self.assertIn(":", file1.context.next_page)
+        self.assertEqual(file1.context.next_page, "blog:setup")
+
+    def test_different_directory_same_app(self):
+        """Test that files in different directories of the same app don't link."""
+        dir1 = Path("/test/docs/basics")
+        dir2 = Path("/test/docs/advanced")
+
+        file1 = self._create_processed_file("intro.md", app="docs", directory=dir1)
+        file2 = self._create_processed_file("performance.md", app="docs", directory=dir2)
+
+        NavigationBuilder.build_navigation([file1, file2], "blog")
+
+        # Same app but different directories - should not link
+        self.assertIsNone(file1.context.next_page)
+        self.assertIsNone(file2.context.prev_page)
+
+    def test_multiple_files_same_directory(self):
+        """Test navigation with many files in the same directory."""
+        files = [
+            self._create_processed_file(f"{i:02d}-file.md")
+            for i in range(1, 6)
+        ]
+
+        NavigationBuilder.build_navigation(files, "blog")
+
+        # First file
+        self.assertIsNone(files[0].context.prev_page)
+        self.assertEqual(files[0].context.next_page, "blog:02-file")
+
+        # Middle files
+        for i in range(1, 4):
+            self.assertEqual(files[i].context.prev_page, f"blog:{i:02d}-file")
+            self.assertEqual(files[i].context.next_page, f"blog:{i+2:02d}-file")
+
+        # Last file
+        self.assertEqual(files[4].context.prev_page, "blog:04-file")
+        self.assertIsNone(files[4].context.next_page)
+
+    def test_case_insensitive_sorting(self):
+        """Test that file sorting is case-insensitive."""
+        file_upper = self._create_processed_file("AAA.md")
+        file_lower = self._create_processed_file("bbb.md")
+
+        NavigationBuilder.build_navigation([file_lower, file_upper], "blog")
+
+        # AAA should come before bbb (case-insensitive)
+        self.assertEqual(file_upper.context.next_page, "blog:bbb")
+        self.assertEqual(file_lower.context.prev_page, "blog:AAA")
+
+
+class TestNavigationBuilderEdgeCases(TestCase):
+    """Test edge cases and error handling for NavigationBuilder."""
+
+    def _create_minimal_file(self, filename: str, app: str = "test"):
+        """Helper to create a minimal ProcessedFile."""
+        context = SpellbookContext(
+            title="Test",
+            url_path="test/path",
+            raw_content="content"
+        )
+        context.namespace = app
+
+        return ProcessedFile(
+            original_path=Path(f"/test/{filename}"),
+            html_content="<p>test</p>",
+            template_path=Path("/templates/test.html"),
+            relative_url=filename.replace('.md', ''),
+            context=context
+        )
+
+    def test_none_namespace_handling(self):
+        """Test handling of files without namespace."""
+        file1 = self._create_minimal_file("file1.md", app="default")
+        file2 = self._create_minimal_file("file2.md", app="default")
+
+        # Should not raise error
+        NavigationBuilder.build_navigation([file1, file2], "blog")
+
+        # Navigation should still work
+        self.assertIsNotNone(file1.context.next_page)
+
+    def test_special_characters_in_filename(self):
+        """Test handling of special characters in filenames."""
+        file1 = self._create_minimal_file("file-with-dashes.md")
+        file2 = self._create_minimal_file("file_with_underscores.md")
+
+        NavigationBuilder.build_navigation([file1, file2], "blog")
+
+        # Should generate valid namespaced URLs with the provided app
+        self.assertIn(":", file1.context.next_page)
+        self.assertIn("blog:", file1.context.next_page)
+
+
+class TestPathBasedNavigation(TestCase):
+    """Tests for path-based navigation frontmatter overrides."""
+
+    def setUp(self):
+        """Set up test fixtures."""
+        self.test_dir = Path("/test/docs")
+
+    def _create_processed_file(self, filename: str, app: str = "blog", directory: Path = None, prev=None, next=None):
+        """Helper to create a ProcessedFile with SpellbookContext."""
+        if directory is None:
+            directory = self.test_dir
+
+        # relative_url should match what get_clean_url produces
+        relative_url = filename.replace('.md', '')
+
+        context = SpellbookContext(
+            title=filename.replace('.md', '').replace('-', ' ').title(),
+            url_path=f"test/{relative_url}",
+            raw_content=f"# {filename}\n\nTest content",
+            prev_page=prev,
+            next_page=next
+        )
+        context.namespace = app
+
+        return ProcessedFile(
+            original_path=directory / filename,
+            html_content=f"<h1>{filename}</h1>",
+            template_path=Path(f"/templates/{filename}.html"),
+            relative_url=relative_url,
+            context=context
+        )
+
+    def test_is_namespaced_format_with_colon(self):
+        """Test detection of namespaced format."""
+        self.assertTrue(NavigationBuilder._is_namespaced_format("blog:page"))
+        self.assertTrue(NavigationBuilder._is_namespaced_format("docs:---introduction"))
+        self.assertTrue(NavigationBuilder._is_namespaced_format("my_app:sub_page"))
+
+    def test_is_namespaced_format_no_colon(self):
+        """Test detection of path format (no colon)."""
+        self.assertFalse(NavigationBuilder._is_namespaced_format("introduction"))
+        self.assertFalse(NavigationBuilder._is_namespaced_format("guides/setup"))
+        self.assertFalse(NavigationBuilder._is_namespaced_format("path/to/page"))
+
+    def test_is_namespaced_format_edge_cases(self):
+        """Test edge cases for format detection."""
+        # Colon after slash = path format
+        self.assertFalse(NavigationBuilder._is_namespaced_format("path/to:file"))
+        # Empty before colon = path format
+        self.assertFalse(NavigationBuilder._is_namespaced_format(":something"))
+        # Slash before colon = path format
+        self.assertFalse(NavigationBuilder._is_namespaced_format("path/:page"))
+
+    def test_path_based_override_simple(self):
+        """Test path-based frontmatter override with simple filename."""
+        file1 = self._create_processed_file("intro.md")
+        file2 = self._create_processed_file("setup.md", prev="intro")  # Path-based
+        file3 = self._create_processed_file("usage.md")
+
+        NavigationBuilder.build_navigation([file1, file2, file3], "blog")
+
+        # file2 should resolve "intro" to "blog:intro"
+        self.assertEqual(file2.context.prev_page, "blog:intro")
+        # Auto next should still work
+        self.assertEqual(file2.context.next_page, "blog:usage")
+
+    def test_path_based_override_with_slash(self):
+        """Test path-based frontmatter override with directory path."""
+        # Create files in different directories
+        dir1 = Path("/test/docs/basics")
+        dir2 = Path("/test/docs/advanced")
+
+        file1 = self._create_processed_file("intro.md", directory=dir1)
+        file2 = self._create_processed_file("config.md", directory=dir2, prev="basics/intro")  # Path with slash
+
+        # Build navigation for both files
+        NavigationBuilder.build_navigation([file1, file2], "blog")
+
+        # file2 should resolve "basics/intro" - but won't find it (different directory)
+        # So it falls back to constructing the URL
+        self.assertEqual(file2.context.prev_page, "blog:basics_intro")
+
+    def test_namespaced_override_still_works(self):
+        """Test that namespaced format overrides still work."""
+        file1 = self._create_processed_file("intro.md")
+        file2 = self._create_processed_file("setup.md", prev="blog:custom-page")  # Namespaced
+        file3 = self._create_processed_file("usage.md")
+
+        NavigationBuilder.build_navigation([file1, file2, file3], "blog")
+
+        # file2 should use namespaced override as-is
+        self.assertEqual(file2.context.prev_page, "blog:custom-page")
+
+    def test_mixed_path_and_namespaced(self):
+        """Test mixing path-based and namespaced overrides."""
+        file1 = self._create_processed_file("intro.md")
+        file2 = self._create_processed_file("setup.md", prev="intro", next="docs:conclusion")  # Mixed!
+        file3 = self._create_processed_file("usage.md")
+
+        NavigationBuilder.build_navigation([file1, file2, file3], "blog")
+
+        # prev should resolve path "intro" to "blog:intro"
+        self.assertEqual(file2.context.prev_page, "blog:intro")
+        # next should use namespaced as-is
+        self.assertEqual(file2.context.next_page, "docs:conclusion")
+
+    def test_path_with_dashes(self):
+        """Test path-based override with dashes in filename."""
+        file1 = self._create_processed_file("01-introduction.md")
+        file2 = self._create_processed_file("02-setup.md", prev="01-introduction")  # Path with dashes
+
+        NavigationBuilder.build_navigation([file1, file2], "blog")
+
+        # Should resolve to namespaced format
+        self.assertEqual(file2.context.prev_page, "blog:01-introduction")
+
+    def test_namespaced_with_triple_dash(self):
+        """Test namespaced format with triple dash in URL name."""
+        file1 = self._create_processed_file("---intro.md")
+        file2 = self._create_processed_file("setup.md", prev="blog:---intro")  # Namespaced with dashes
+
+        NavigationBuilder.build_navigation([file1, file2], "blog")
+
+        # Should recognize as namespaced and use as-is
+        self.assertEqual(file2.context.prev_page, "blog:---intro")


### PR DESCRIPTION
# Feature: Automatic Prev/Next Navigation with Path-Based Frontmatter

## What We Built

Auto-linking prev/next navigation for markdown files. Works automatically, supports both simple paths and namespaced URLs in frontmatter.

## What's New

### 1. Zero-Config Navigation
Files auto-link alphabetically within directories:
```
blog/
  01-intro.md  → next: 02-setup
  02-setup.md  → prev: 01-intro
```

- Directory boundaries respected
- App isolation (blog ≠ docs)

### 2. Dual-Format Frontmatter
Path-based (easy):
```yaml
prev: introduction
next: advanced/config
```

Namespaced (precise):
```yaml
prev: blog:custom-page
next: docs:---special-intro
```

Mix both:
```yaml
prev: intro           # path
next: docs:conclusion # namespaced
```

### 3. Smart Detection
- `blog:page` → namespaced
- `docs:---intro` → namespaced (handles dashes)
- `introduction` → path
- `guides/setup` → path

### 4. Clean UI
- Borderless navigation buttons
- Theme-aware (dark mode works)
- Smooth hover transitions
- No JavaScript

## Files Changed

**Created:**
- `navigation.py` (230 lines) - NavigationBuilder
- `test_navigation.py` (25 tests)

**Modified:**
- `frontmatter.py` - Extract prev/next from YAML
- `url_view_generator.py` - Call NavigationBuilder
- `context.py` - Include prev/next in metadata
- `for_user.html` - Button styling
- `for_dev.html` - Theme colors
- `test_url_view_generator.py` - Mock updates

## Test Results

**699 tests passing** (25 new navigation tests)

## Breaking Changes

**None.** Purely additive, fully backward compatible.

## Usage

**Automatic (no config):**
```bash
python manage.py spellbook_md
```

**Custom (optional):**
```yaml
---
prev: intro
next: getting-started
---
```

## How It Works

1. Group files by directory + app
2. Sort alphabetically
3. Check frontmatter → normalize format → link neighbors

Path format searches files and converts to namespaced URLs. Namespaced format used as-is.
